### PR TITLE
refactor: use unsubscibe method to remove listeners

### DIFF
--- a/packages/libregl/src/components/marker.ts
+++ b/packages/libregl/src/components/marker.ts
@@ -16,8 +16,9 @@ import {
   Alignment,
   PointLike,
   LngLat,
+  Subscription,
 } from 'maplibre-gl'
-import { ListenerRegistery, markerKey } from '../types'
+import { markerKey } from '../types'
 import { useContext } from '../hooks/core'
 import { normalizeOptions } from '../util'
 
@@ -81,7 +82,7 @@ export const Marker = defineComponent({
       }
     )
 
-    const listeners = shallowRef<ListenerRegistery<EventType>>([])
+    const listeners = shallowRef<Subscription[]>([])
     const bindEventListeners = () => {
       bindEvent('dragstart', props.onDragStart!)
       bindEvent('drag', props.onDrag!)
@@ -114,18 +115,13 @@ export const Marker = defineComponent({
           })
         }
       }
-      marker.value.on(type, listener)
-      listeners.value.push({
-        type,
-        listener,
-      })
+      const subscription = marker.value.on(type, listener)
+      listeners.value.push(subscription)
     }
 
     const removeEventListeners = () => {
       if (!listeners.value.length) return
-      listeners.value.forEach(({ type, listener }) => {
-        marker.value.off(type, listener)
-      })
+      listeners.value.forEach((subscription) => subscription.unsubscribe())
       listeners.value = []
     }
     watchEffect(() => {


### PR DESCRIPTION
Remove listeners via unsubscribe method instead of removing them by type and listener.

Refactors: `Marker` and `GeoLocateControl` components.